### PR TITLE
Evolution of the `path` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # tablexlsx (WIP)
 
-* (fix) `toxlsx()` no longer fails when the `object` argument is the result of a computation #18
-* provide meaningful error message if merge cols don't exist #20
+* (fix) `toxlsx()` no longer fails when the `object` argument is the result of a computation (#18)
+* provide meaningful error message if merge cols don't exist (#20)
+* `path` can now be supplied as a file name with full path instead of a directory name (#29)
 
 # tablexlsx 1.0.0
 

--- a/R/toxlsx.R
+++ b/R/toxlsx.R
@@ -8,6 +8,7 @@
 #' See examples gallery : <https://ddotta.github.io/tablexlsx/articles/aa-examples.html>
 #'
 #' @param object data.frame to be converted to excel
+#' @param path path to save excel file
 #' @param tosheet list of sheet names for each element of object.
 #'   If omitted, sheets are named by default "Sheet 1", "Sheet 2"...
 #' @param title list of title for each element of object
@@ -23,7 +24,6 @@
 #' @param mergecol list of character vectors that indicate the columns for which we want to merge the modalities
 #' @param bygroup list of character vectors indicating the names of the columns by which to group
 #' @param groupname list of booleans indicating whether the names of the grouping variables should be written
-#' @param path path to save excel file
 #' @param filename name for the excel file ("Export" by default)
 #' @param asTable logical indicating if data should be written as an Excel Table (FALSE by default)
 #' @param automaticopen logical indicating if excel file should open automatically (FALSE by default)
@@ -40,6 +40,7 @@
 #' @export
 #'
 toxlsx <- function(object,
+                   path,
                    tosheet = list(),
                    title = list(),
                    columnstyle = list("default" = NULL),
@@ -49,7 +50,6 @@ toxlsx <- function(object,
                    mergecol = NULL,
                    bygroup = list(),
                    groupname = FALSE,
-                   path,
                    filename = "Export",
                    asTable = FALSE,
                    automaticopen = FALSE) {

--- a/R/toxlsx.R
+++ b/R/toxlsx.R
@@ -8,7 +8,7 @@
 #' See examples gallery : <https://ddotta.github.io/tablexlsx/articles/aa-examples.html>
 #'
 #' @param object data.frame to be converted to excel
-#' @param path path to save excel file
+#' @param path path to save excel file (either a directory name or a file name with full path)
 #' @param tosheet list of sheet names for each element of object.
 #'   If omitted, sheets are named by default "Sheet 1", "Sheet 2"...
 #' @param title list of title for each element of object
@@ -24,7 +24,7 @@
 #' @param mergecol list of character vectors that indicate the columns for which we want to merge the modalities
 #' @param bygroup list of character vectors indicating the names of the columns by which to group
 #' @param groupname list of booleans indicating whether the names of the grouping variables should be written
-#' @param filename name for the excel file ("Export" by default)
+#' @param filename name for the excel file ("Export" by default). Ignored if `path` is a file name.
 #' @param asTable logical indicating if data should be written as an Excel Table (FALSE by default)
 #' @param automaticopen logical indicating if excel file should open automatically (FALSE by default)
 #'

--- a/R/toxlsx.R
+++ b/R/toxlsx.R
@@ -254,18 +254,22 @@ toxlsx <- function(object,
 
   }
 
+  if (dir.exists(path)) {
+    full_path <- file.path(path, paste0(filename,".xlsx"))
+  } else {
+    full_path <- path
+    if (filename != "Export") warning("The supplied filename was overriden by the supplied path.")
+  }
+
   # Save workbook
   openxlsx::saveWorkbook(
     wb,
-    file.path(
-      path,
-      paste0(filename,".xlsx")
-    ),
+    full_path,
     overwrite = TRUE
   )
 
   Sys.sleep(0.01)
-  cli_alert_success("\nYour Excel file '{filename}.xlsx' is available in the folder '{path}'")
+  cli_alert_success("\nYour Excel file '{basename(full_path)}' is available in the folder '{dirname(full_path)}'")
 
   # Open workbook automatically if automaticopen is TRUE
   if (isTRUE(automaticopen)) {

--- a/man/toxlsx.Rd
+++ b/man/toxlsx.Rd
@@ -6,6 +6,7 @@
 \usage{
 toxlsx(
   object,
+  path,
   tosheet = list(),
   title = list(),
   columnstyle = list(default = NULL),
@@ -15,7 +16,6 @@ toxlsx(
   mergecol = NULL,
   bygroup = list(),
   groupname = FALSE,
-  path,
   filename = "Export",
   asTable = FALSE,
   automaticopen = FALSE
@@ -23,6 +23,8 @@ toxlsx(
 }
 \arguments{
 \item{object}{data.frame to be converted to excel}
+
+\item{path}{path to save excel file (either a directory name or a file name with full path)}
 
 \item{tosheet}{list of sheet names for each element of object.
 If omitted, sheets are named by default "Sheet 1", "Sheet 2"...}
@@ -48,9 +50,7 @@ If omitted, no footnote3}
 
 \item{groupname}{list of booleans indicating whether the names of the grouping variables should be written}
 
-\item{path}{path to save excel file}
-
-\item{filename}{name for the excel file ("Export" by default)}
+\item{filename}{name for the excel file ("Export" by default). Ignored if `path` is a file name.}
 
 \item{asTable}{logical indicating if data should be written as an Excel Table (FALSE by default)}
 


### PR DESCRIPTION
The `path` argument is now in second position + it can now be supplied as a file name with full path instead of a directory name (fixes #29).

For backward compatibility, the `filename` argument is used if path is a directory name. If that is not the case, the `filename` argument is ignored.